### PR TITLE
workaround: open detailed tour page in a new window

### DIFF
--- a/src/Resources/contao/templates/modules/calendar/event_list/event_list_partial_course.html5
+++ b/src/Resources/contao/templates/modules/calendar/event_list/event_list_partial_course.html5
@@ -12,13 +12,13 @@
       <div class="row">
         <!-- Start left col -->
         <div class="col-sm-3 col-xl-5 d-none d-sm-block">
-          <a v-bind:href="row.eventUrl" v-bind:title="row.title" v-html="row.eventImage" class="responsive event-title-link"></a>
+          <a v-bind:href="row.eventUrl" target="_blank" v-bind:title="row.title" v-html="row.eventImage" class="responsive event-title-link"></a>
         </div>
         <!-- Start right col -->
         <div class="col-sm-9 col-xl-7">
           <div class="title d-flex align-items-start lh-1">
             <span class="event-state-icon pt-1" data-toggle="tooltip" data-placement="top" v-bind:aria-label="row.eventStateLabel" v-bind:title="row.eventStateLabel" v-bind:class="row.eventState"> </span>
-            <a v-bind:href="row.eventUrl" class="event-title-link">
+            <a v-bind:href="row.eventUrl" target="_blank" class="event-title-link">
               <h4 class="d-flex headline">
                 {{ row.title }}
               </h4>

--- a/src/Resources/contao/templates/modules/calendar/event_list/event_list_partial_tour.html5
+++ b/src/Resources/contao/templates/modules/calendar/event_list/event_list_partial_tour.html5
@@ -10,7 +10,7 @@
 
       <div class="event-list-inner-box d-flex p-3 mb-3">
         <!-- left col -->
-        <div class="event-list-tour-col-1" v-bind:onclick="'window.location.href=\'' + row.eventUrl + '\''">
+        <div class="event-list-tour-col-1" v-bind:onclick="'window.open(\'' + row.eventUrl + '\')'">
           <div class="event-list-badge-wrapper me-4 rounded-circle d-flex align-items-center justify-content-center">
             <div class="d-flex flex-column">
               <span class="event-list-badge-day small text-center">
@@ -45,7 +45,7 @@
             <span data-toggle="tooltip" data-placement="top" v-bind:aria-label="row.eventStateLabel" v-bind:title="row.eventStateLabel">
               <i class="event-state-icon fa-fw" v-bind:class="row.eventState"></i>
             </span>
-            <a v-bind:href="row.eventUrl" class="event-title-link font-weight-bold"><strong>{{ row.eventTitle }}</strong></a>
+            <a v-bind:href="row.eventUrl" target="_blank" class="event-title-link font-weight-bold"><strong>{{ row.eventTitle }}</strong></a>
           </div>
           <!-- end row state icon -->
 


### PR DESCRIPTION
suggestion of a workaround for poor back button behaviour in browsers because scroll position of previously loaded events with "weitere Events laden?" is not restored after detailed tour was opened before