### PR TITLE
fix: align output of event state for tours according to courses

### DIFF
--- a/src/Resources/contao/templates/modules/calendar/event_reader/event_tour_detailview_sac.html5
+++ b/src/Resources/contao/templates/modules/calendar/event_reader/event_tour_detailview_sac.html5
@@ -4,7 +4,7 @@
 <p class="back"><a href="javascript:history.go(-1)" title="Zurück">Zurück</a></p>
 
 <div class="event event-detailview layout_full block<?= $this->getEventData('class') ?>">
-  <?php if ($this->eventState): ?>
+  <?php if ($this->getEventData('eventState')): ?>
   <h4 class="event-state-headline mb-0"><?= $this->getEventData('eventStateLabel') ?></h4>
   <?php endif; ?>
 


### PR DESCRIPTION
I propose the same behaviour of event state for tour and course detail pages.
Before: Only tour's event states like cancelled or fully booked were displayed as text, but no information about outside of booking period, waiting list etc.

@markocupic Please review and test it. I think I found an inconsistency. Thank you.