### PR TITLE
style: use proper label for confirmed participants in getBookingCounter

### DIFF
--- a/src/Resources/contao/classes/CalendarEventsHelper.php
+++ b/src/Resources/contao/classes/CalendarEventsHelper.php
@@ -886,7 +886,7 @@ class CalendarEventsHelper
                 }
             } else {
                 // There is no booking limit. Show registered members
-                return sprintf($strBadge, 'dark', $memberCount.' Anmeldungen', $memberCount.'/?');
+                return sprintf($strBadge, 'dark', $memberCount.' bestätigte Plätze', $memberCount.'/?');
             }
         }
 


### PR DESCRIPTION
Proposal to use better 'x bestätigte Plätze' instead of 'x Anmeldungen' for unlimited events (little bit misleading because the number of confirmed members will be displayed and not the number of confirmed and UNconfirmed registrations). 
The label 'noch x freie Plätze' is used for limited events.