### PR TITLE
feat: add explanation in brackets after appr. of difficulties for tour detail page

### DIFF
--- a/src/Resources/contao/classes/CalendarEventsHelper.php
+++ b/src/Resources/contao/classes/CalendarEventsHelper.php
@@ -740,7 +740,7 @@ class CalendarEventsHelper
                         $html = '<span class="badge badge-pill bg-primary" data-toggle="tooltip" data-placement="top" title="Techn. Schwierigkeit: %s">%s</span>';
                         $arrReturn[] = sprintf($html, $strDiffTitle, $strDiff);
                     } else {
-                        $arrReturn[] = $strDiff;
+                        $arrReturn[] = $strDiff.' ('.$strDiffTitle.')'
                     }
                 }
             }


### PR DESCRIPTION
For tour detail page:
New example: "WS - ZS (wenig schwierig - ziemlich schwierig)"
Actual example: "WS - ZS"

@markocupic What do you think about this proposal? Does this small change work at all? Any other dependencies? Thank you.