### PR TITLE
Feat/booking counter

### DIFF
--- a/src/Resources/contao/classes/CalendarEventsHelper.php
+++ b/src/Resources/contao/classes/CalendarEventsHelper.php
@@ -184,6 +184,10 @@ class CalendarEventsHelper
                 $value = static::getBookingCounter($objEvent);
                 break;
 
+            case 'bookingCounterAsText':
+                $value = static::getBookingCounter($objEvent, true);
+                break;
+
             case 'tourTechDifficultiesAsArray':
                 $value = static::getTourTechDifficultiesAsArray($objEvent, false);
                 break;
@@ -802,9 +806,13 @@ class CalendarEventsHelper
         return $arrReturn;
     }
 
-    public static function getBookingCounter(CalendarEventsModel $objEvent): string
+    public static function getBookingCounter(CalendarEventsModel $objEvent, bool $withoutTooltip = false): string
     {
-        $strBadge = '<span class="badge badge-pill bg-%s" data-bs-toggle="tooltip" data-placement="top" title="%s">%s</span>';
+        if (!$withoutTooltip) {
+            $strBadge = '<span class="badge badge-pill bg-%s" data-bs-toggle="tooltip" data-placement="top" title="%s">%s</span>';
+        } else {
+            $strBadge = '%2$s (%3$s)';  // only text as output, e.g. 'noch 1 freie Plätze (5/6)`
+        }
 
         $calendarEventsMember = Database::getInstance()
             ->prepare('SELECT * FROM tl_calendar_events_member WHERE eventId = ? && stateOfSubscription = ?')

--- a/src/Resources/contao/classes/CalendarEventsHelper.php
+++ b/src/Resources/contao/classes/CalendarEventsHelper.php
@@ -808,9 +808,8 @@ class CalendarEventsHelper
 
     public static function getBookingCounter(CalendarEventsModel $objEvent, bool $withoutTooltip = false): string
     {
-        if (!$withoutTooltip) {
-            $strBadge = '<span class="badge badge-pill bg-%s" data-bs-toggle="tooltip" data-placement="top" title="%s">%s</span>';
-        } else {
+        $strBadge = '<span class="badge badge-pill bg-%s" data-bs-toggle="tooltip" data-placement="top" title="%s">%s</span>';
+        if ($withoutTooltip) {
             $strBadge = '%2$s (%3$s)';  // only text as output, e.g. 'noch 1 freie Plätze (5/6)`
         }
 

--- a/src/Resources/contao/templates/modules/calendar/event_reader/event_kurs_detailview_sac.html.twig
+++ b/src/Resources/contao/templates/modules/calendar/event_reader/event_kurs_detailview_sac.html.twig
@@ -226,6 +226,13 @@
                     </div>
                 {% endif %}
 
+                {% if not getEventData.invoke('bookingCounterAsText') is empty %}
+                    <div class="booking-counter event-detail event-info-box icon-box-small">
+                        <h5>Bestätigte Anmeldungen</h5>
+                        <p>{{ getEventData.invoke('bookingCounterAsText') }}</p>
+                    </div>
+                {% endif %}
+
             </div>
         </div>
         <!--end col right -->

--- a/src/Resources/contao/templates/modules/calendar/event_reader/event_kurs_detailview_sac.html.twig
+++ b/src/Resources/contao/templates/modules/calendar/event_reader/event_kurs_detailview_sac.html.twig
@@ -97,6 +97,7 @@
         <div class="col-12">
             <div class="p-4 bg-white">
                 <div class="booking-text event-detail event-info-box icon-box-small">
+                
                     {% if not getEventData.invoke('bookingEvent') is empty or getEventData.invoke('generateMainInstructorContactDataFromDb') %}
                         <h5>Anmeldung</h5>
                         <p>{% if getEventData.invoke('disableOnlineRegistration') %}Keine {% endif %}Online-Anmeldung</p>

--- a/src/Resources/contao/templates/modules/calendar/event_reader/event_tour_detailview_sac.html.twig
+++ b/src/Resources/contao/templates/modules/calendar/event_reader/event_tour_detailview_sac.html.twig
@@ -110,6 +110,13 @@
                     </div>
                 {% endif %}
 
+                {% if not getEventData.invoke('bookingCounterAsText') is empty %}
+                    <div class="booking-counter event-detail event-info-box icon-box-small">
+                        <h5>Bestätigte Anmeldungen</h5>
+                        <p>{{ getEventData.invoke('bookingCounterAsText') }}</p>
+                    </div>
+                {% endif %}
+
             </div>
 
             <div class="mt-3 mb-3 p-4 bg-white">

--- a/src/Resources/contao/templates/modules/calendar/event_reader/event_tour_detailview_sac.html.twig
+++ b/src/Resources/contao/templates/modules/calendar/event_reader/event_tour_detailview_sac.html.twig
@@ -120,9 +120,9 @@
             </div>
 
             <div class="mt-3 mb-3 p-4 bg-white">
+                <div class="booking-text event-detail event-info-box icon-box-small">
 
-                {% if not getEventData.invoke('bookingEvent') is empty or getEventData.invoke('generateMainInstructorContactDataFromDb') %}
-                    <div class="booking-text event-detail event-info-box icon-box-small">
+                    {% if not getEventData.invoke('bookingEvent') is empty or getEventData.invoke('generateMainInstructorContactDataFromDb') %}
                         <h5>Anmeldung</h5>
                         <p>{% if getEventData.invoke('disableOnlineRegistration') %}Keine {% endif %}Online-Anmeldung</p>
 
@@ -133,28 +133,28 @@
                         {% if getEventData.invoke('generateMainInstructorContactDataFromDb') %}
                             <p class="mt-3">{{ getEventData.invoke('mainInstructorContactDataFromDb')|raw }}</p>
                         {% endif %}
-                    </div>
-                {% endif %}
-
-                <!-- buttons -->
-                <div class="d-flex flex-wrap">
-                    <div class="mt-3 me-3">
-                        <a href="_download/download_event_ical?eventId={{ getEventData.invoke('id') }}" title="Event in Kalender importieren" class="btn btn-block btn-outline-primary">
-                            <i class="fal fa-calendar-plus"></i> iCal download
-                        </a>
-                    </div>
-
-                    {% if not getEventData.invoke('disableOnlineRegistration') %}
-                        <div class="event-detail-buttons mt-3">
-                            <!-- "book event" button -->
-                            <!-- indexer::continue -->
-                            {{ "{{insert_module::408}}" }}
-                            <!-- indexer::stop -->
-                        </div>
                     {% endif %}
-                </div>
-                <!-- end buttons -->
 
+                    <!-- buttons -->
+                    <div class="d-flex flex-wrap">
+                        <div class="mt-3 me-3">
+                            <a href="_download/download_event_ical?eventId={{ getEventData.invoke('id') }}" title="Event in Kalender importieren" class="btn btn-block btn-outline-primary">
+                                <i class="fal fa-calendar-plus"></i> iCal download
+                            </a>
+                        </div>
+
+                        {% if not getEventData.invoke('disableOnlineRegistration') %}
+                            <div class="event-detail-buttons mt-3">
+                                <!-- "book event" button -->
+                                <!-- indexer::continue -->
+                                {{ "{{insert_module::408}}" }}
+                                <!-- indexer::stop -->
+                            </div>
+                        {% endif %}
+                    </div>
+                    <!-- end buttons -->
+
+                </div>
             </div>
         </div>
         <!-- End col left -->

--- a/src/Resources/contao/templates/modules/calendar/event_reader/event_tour_detailview_sac.html.twig
+++ b/src/Resources/contao/templates/modules/calendar/event_reader/event_tour_detailview_sac.html.twig
@@ -253,13 +253,13 @@
                         {% if not getEventData.invoke('linkSacRoutePortal') is empty %}
                             <div class="me-2 mt-3 mb-3">
                                 <a href="{{ getEventData.invoke('linkSacRoutePortal') }}" target="_blank" title="Routen-Details auf SAC-Tourenportal" class="btn btn-block btn-primary">
-                                    <i class="fal fa-compass"></i> SAC-Tourenportal
+                                    <i class="fal fa-compass"></i> Route auf SAC-Tourenportal
                                 </a>
                             </div>
                         {% endif %}
 
                         <div class="me-2 mt-3 mb-3">
-                            <a href="{{ '{{link_url::ausruestungslisten}}' }}" target="_blank" title="Hier geht es zur Ausrüstungsempfehlung unserer SAC-Tourenleiter" class="btn btn-block btn-outline-primary">
+                            <a href="{{ '{{link_url::ausruestungslisten}}' }}" target="_blank" title="Hier geht es zur Ausrüstungsempfehlung unserer SAC-Tourenleitenden" class="btn btn-block btn-outline-primary">
                                 <i class="fal fa-gear"></i> Ausrüstungsempfehlung
                             </a>
                         </div>


### PR DESCRIPTION
feat: add the booking counter as text to the detailed page of events as well (not only in the event list).

Example:
![grafik](https://user-images.githubusercontent.com/99007003/181567980-94604a22-8f58-4ecc-8637-ee8a1c152d5a.png)

Advantage:
Participants see that the "**bestätigte** Anmeldungen" is relevant.

This would complete the feature: 
https://github.com/jonasmueller1/sac-pilatus-website/issues/2

@markocupic What do you think about integrating it? Thank you.