### PR TITLE
feat: add login info for download section of tours and courses

### DIFF
--- a/src/Resources/contao/templates/modules/calendar/event_reader/event_kurs_detailview_sac.html.twig
+++ b/src/Resources/contao/templates/modules/calendar/event_reader/event_kurs_detailview_sac.html.twig
@@ -235,11 +235,11 @@
 
     {# enclosures/downloads #}
     {# !Urheberrechtsverletzung bei urheberrechtlich geschützten Anhängen wie Topos, Karten, etc. #}
-    {% if hasLoggedInFrontendUser or 'eventPreview' == app.request.query.get('modee') %}
-        {% if getEventData.invoke('enclosure') %}
-            <div class="box-layout-transparent">
-                <div class="event-eclosures event-detail event-info-box icon-box-small">
-                    <h5>Downloads/weitere Informationen</h5>
+    {% if getEventData.invoke('enclosure') %}
+        <div class="box-layout-transparent">
+            <div class="event-eclosures event-detail event-info-box icon-box-small">
+                <h5>Downloads / Weitere Informationen</h5>
+                {% if hasLoggedInFrontendUser or 'eventPreview' == app.request.query.get('modee') %}
                     <div class="enclosure">
                         {% for enclosureItem in enclosure %}
                             <p>
@@ -248,9 +248,11 @@
                             </p>
                         {% endfor %}
                     </div>
-                </div>
+                {% else %}
+                    <p>Bitte einloggen, um die Anlagen anschauen zu können.</p>
+                {% endif %}
             </div>
-        {% endif %}
+        </div>
     {% endif %}
 
     {# gallery start #}

--- a/src/Resources/contao/templates/modules/calendar/event_reader/event_tour_detailview_sac.html.twig
+++ b/src/Resources/contao/templates/modules/calendar/event_reader/event_tour_detailview_sac.html.twig
@@ -273,11 +273,11 @@
 
     {# enclosures/downloads #}
     {# !Urheberrechtsverletzung bei urheberrechtlich geschützten Anhängen wie Topos, Karten, etc. #}
-    {% if hasLoggedInFrontendUser or 'eventPreview' == app.request.query.get('modee') %}
-        {% if getEventData.invoke('enclosure') %}
-            <div class="box-layout-transparent">
-                <div class="event-eclosures event-detail event-info-box icon-box-small">
-                    <h5>Downloads/weitere Informationen</h5>
+    {% if getEventData.invoke('enclosure') %}
+        <div class="box-layout-transparent">
+            <div class="event-eclosures event-detail event-info-box icon-box-small">
+                <h5>Downloads / Weitere Informationen</h5>
+                {% if hasLoggedInFrontendUser or 'eventPreview' == app.request.query.get('modee') %}
                     <div class="enclosure">
                         {% for enclosureItem in enclosure %}
                             <p>
@@ -286,9 +286,11 @@
                             </p>
                         {% endfor %}
                     </div>
-                </div>
+                {% else %}
+                    <p>Bitte einloggen, um die Anlagen anschauen zu können.</p>
+                {% endif %}
             </div>
-        {% endif %}
+        </div>
     {% endif %}
 
     {# gallery start #}


### PR DESCRIPTION
@markocupic I added a small hint for the download section. Thanks!

Open point:
It seems that the following condition doesn't work anymore in both *.twig templates:
`'eventPreview' == app.request.query.get('modee')`