### PR TITLE
fix/jahresprogramm

### DIFF
--- a/src/DataContainer/CalendarEvents.php
+++ b/src/DataContainer/CalendarEvents.php
@@ -519,7 +519,7 @@ class CalendarEvents
                             $objUser = $this->userModel->findByPk($objEvent->{$field});
                             $arrRow[] = null !== $objUser ? html_entity_decode($objUser->lastname.' '.$objUser->firstname) : '';
                         } elseif ('tourTechDifficulty' === $field) {
-                            $arrDiff = $this->calendarEventsHelper->getTourTechDifficultiesAsArray($objEvent->current(), false);
+                            $arrDiff = $this->calendarEventsHelper->getTourTechDifficultiesAsArray($objEvent->current(), false, false);
                             $arrRow[] = implode(' und ', $arrDiff);
                         } elseif ('eventDates' === $field) {
                             $arrTimestamps = $this->calendarEventsHelper->getEventTimestamps($objEvent->current());

--- a/src/DocxTemplator/Helper/Event.php
+++ b/src/DocxTemplator/Helper/Event.php
@@ -109,7 +109,7 @@ class Event
 
         $objPhpWord->replace('eventDates', $this->prepareString($strEventDuration));
         $objPhpWord->replace('eventMeetingpoint', $this->prepareString($objEvent->meetingPoint));
-        $objPhpWord->replace('eventTechDifficulties', $this->prepareString(implode(', ', $calendarEventsHelperAdapter->getTourTechDifficultiesAsArray($objEvent, false))));
+        $objPhpWord->replace('eventTechDifficulties', $this->prepareString(implode(', ', $calendarEventsHelperAdapter->getTourTechDifficultiesAsArray($objEvent, false, false))));
         $objPhpWord->replace('eventEquipment', $this->prepareString($objEvent->equipment), ['multiline' => true]);
         $objPhpWord->replace('eventTourProfile', $this->prepareString($strTourProfile), ['multiline' => true]);
         $objPhpWord->replace('emergencyConcept', $this->prepareString($strEmergencyConcept), ['multiline' => true]);

--- a/src/Resources/contao/classes/CalendarEventsHelper.php
+++ b/src/Resources/contao/classes/CalendarEventsHelper.php
@@ -191,11 +191,15 @@ class CalendarEventsHelper
                 break;
 
             case 'tourTechDifficultiesAsArray':
-                $value = static::getTourTechDifficultiesAsArray($objEvent, false);
+                $value = static::getTourTechDifficultiesAsArray($objEvent, false, false);
+                break;
+
+            case 'tourTechDifficultiesAsArrayWithExplanation':
+                $value = static::getTourTechDifficultiesAsArray($objEvent, false, true);
                 break;
 
             case 'tourTechDifficulties':
-                $value = implode(' ', static::getTourTechDifficultiesAsArray($objEvent, true));
+                $value = implode(' ', static::getTourTechDifficultiesAsArray($objEvent, true, false));
                 break;
 
             case 'instructors':
@@ -764,7 +768,7 @@ class CalendarEventsHelper
         return '<span class="badge badge-pill bg-success" data-bs-toggle="tooltip" data-placement="top" title="Anreise mit ÖV">ÖV</span>';
     }
 
-    public static function getTourTechDifficultiesAsArray(CalendarEventsModel $objEvent, bool $tooltip = false): array
+    public static function getTourTechDifficultiesAsArray(CalendarEventsModel $objEvent, bool $tooltip = false, bool $explanation = false): array
     {
         $arrReturn = [];
 
@@ -803,8 +807,10 @@ class CalendarEventsHelper
                     if ($tooltip) {
                         $html = '<span class="badge badge-pill bg-primary" data-bs-toggle="tooltip" data-placement="top" title="Techn. Schwierigkeit: %s">%s</span>';
                         $arrReturn[] = sprintf($html, $strDiffTitle, $strDiff);
-                    } else {
+                    } elseif ($explanation) {
                         $arrReturn[] = $strDiff.' ('.$strDiffTitle.')';
+                    } else {
+                        $arrReturn[] = $strDiff;
                     }
                 }
             }

--- a/src/Resources/contao/templates/modules/calendar/event_reader/event_tour_detailview_sac.html.twig
+++ b/src/Resources/contao/templates/modules/calendar/event_reader/event_tour_detailview_sac.html.twig
@@ -169,7 +169,7 @@
                 {% if getEventData.invoke('eventType') == 'tour' %}
                     <div class="tour-difficulties event-detail event-info-box icon-box-small">
                         <h5>Schwierigkeit</h5>
-                        <p>{{ getEventData.invoke('tourTechDifficultiesAsArray')|join('<br>')|raw }}</p>
+                        <p>{{ getEventData.invoke('tourTechDifficultiesAsArrayWithExplanation')|join('<br>')|raw }}</p>
                     </div>
                 {% endif %}
 


### PR DESCRIPTION
fix: tour difficulties without explanation for the export of 'Jahresprogramm'

@markocupic Fix for the comment https://github.com/markocupic/sac-event-tool-bundle/pull/11#issuecomment-1247691654.
Example:
- Jahresprogramm: "WS - ZS"
- Tour detail page: "WS  - ZS (wenig schwierig - ziemlich schwierig)

Thank you for reviewing.

