### PR TITLE
feat/small-email-fix

### DIFF
--- a/src/Resources/contao/templates/backend/tl_calendar_events_member/be_email_templ_accept_registration.html5
+++ b/src/Resources/contao/templates/backend/tl_calendar_events_member/be_email_templ_accept_registration.html5
@@ -11,7 +11,7 @@ Bitte antworte nicht auf diese Nachricht, sondern nutze für Fragen bitte:
 <?= $this->instructorEmail ?>
 
 
-Freundliche Grüsse
+Beste Grüsse
 
 <?= $this->instructorName ?>
 

--- a/src/Resources/contao/templates/backend/tl_calendar_events_member/be_email_templ_accept_registration.html5
+++ b/src/Resources/contao/templates/backend/tl_calendar_events_member/be_email_templ_accept_registration.html5
@@ -10,6 +10,7 @@ Du bist für den Event "<?= $this->eventName ?>" definitiv angemeldet und deine 
 Bitte antworte nicht auf diese Nachricht, sondern nutze für Fragen bitte: 
 <?= $this->instructorEmail ?>
 
+
 Freundliche Grüsse
 
 <?= $this->instructorName ?>

--- a/src/Resources/contao/templates/backend/tl_calendar_events_member/be_email_templ_added_to_waitlist.html5
+++ b/src/Resources/contao/templates/backend/tl_calendar_events_member/be_email_templ_added_to_waitlist.html5
@@ -10,6 +10,7 @@ Leider kann ich dir für den Event "<?= $this->eventName ?>" im Moment noch kein
 Bitte antworte nicht auf diese Nachricht, sondern nutze für Fragen bitte: 
 <?= $this->instructorEmail ?>
 
+
 Freundliche Grüsse
 
 <?= $this->instructorName ?>

--- a/src/Resources/contao/templates/backend/tl_calendar_events_member/be_email_templ_added_to_waitlist.html5
+++ b/src/Resources/contao/templates/backend/tl_calendar_events_member/be_email_templ_added_to_waitlist.html5
@@ -11,7 +11,7 @@ Bitte antworte nicht auf diese Nachricht, sondern nutze für Fragen bitte:
 <?= $this->instructorEmail ?>
 
 
-Freundliche Grüsse
+Beste Grüsse
 
 <?= $this->instructorName ?>
 

--- a/src/Resources/contao/templates/backend/tl_calendar_events_member/be_email_templ_refuse_registration.html5
+++ b/src/Resources/contao/templates/backend/tl_calendar_events_member/be_email_templ_refuse_registration.html5
@@ -11,6 +11,7 @@ Ich danke dir für dein Verständnis.
 Bitte antworte nicht auf diese Nachricht, sondern nutze für Fragen bitte: 
 <?= $this->instructorEmail ?>
 
+
 Freundliche Grüsse
 
 <?= $this->instructorName ?>

--- a/src/Resources/contao/templates/backend/tl_calendar_events_member/be_email_templ_refuse_registration.html5
+++ b/src/Resources/contao/templates/backend/tl_calendar_events_member/be_email_templ_refuse_registration.html5
@@ -12,7 +12,7 @@ Bitte antworte nicht auf diese Nachricht, sondern nutze für Fragen bitte:
 <?= $this->instructorEmail ?>
 
 
-Freundliche Grüsse
+Beste Grüsse
 
 <?= $this->instructorName ?>
 


### PR DESCRIPTION
feat: add an empty line between email and greeting which was not shown in output/email

Current output:

> Bitte antworte nicht auf diese Nachricht, sondern nutze für Fragen bitte: 
> asd@asd.ch
> Freundliche Grüsse
>
> Xxx Yyy

Target output:

> Bitte antworte nicht auf diese Nachricht, sondern nutze für Fragen bitte: 
> asd@asd.ch
>
> Beste Grüsse
>
> Xxx Yyy


@markocupic Thanks!