### PR TITLE
feature/list-past-events-dashboard

### DIFF
--- a/contao/languages/en/default.php
+++ b/contao/languages/en/default.php
@@ -107,6 +107,7 @@ $GLOBALS['TL_LANG']['MSC']['emailSentToEventMembers'] = 'Der/die Teilnehmer wurd
 
 // Backend member dashboard
 $GLOBALS['TL_LANG']['MSC']['bmd_yourUpcomingEvents'] = 'Ihre nächsten Events';
+$GLOBALS['TL_LANG']['MSC']['bmd_yourPastEvents'] = 'Ihre vergangenen Events';
 $GLOBALS['TL_LANG']['MSC']['bmd_howToEditReadonlyProfileData'] = 'Änderungen an Name, Adresse, Telefon und E-Mail müssen auf der Webseite des SAC Zentralverbandes (https://sac-cas.ch) gemacht werden.';
 
 // Event registration frontend module


### PR DESCRIPTION
- feat: list last 10 events in dashboard (backend)

@markocupic What do you think about such a list in the dashboard/backend? 
It is very helpful to point to the "Rapport" (text added) and for the "Toureneingabe" to compare or copy something from last season.
Thank you for your opinion.
As always, I can't test it, just brain compiling... ;-)