### PR TITLE
fix/add-mountain-guide-courses

### DIFF
--- a/contao/templates/modules/calendar/event_reader/event_kurs_detailview_sac.html.twig
+++ b/contao/templates/modules/calendar/event_reader/event_kurs_detailview_sac.html.twig
@@ -59,6 +59,12 @@
                         <p>Keine Gruppe ausgewählt</p>
                     {% endif %}
                 </div>
+                
+                {% if get_event_data(model, 'mountainguide') %}
+                    <div class="eventdate event-detail event-info-box icon-box-small">
+                        <h5>Mit Bergführer/in</h5>
+                    </div>
+                {% endif %}
 
                 {% if not get_event_data(model, 'courseId') is empty %}
                     <!-- indexer::continue -->


### PR DESCRIPTION
- fix: add mountain guide option for detail page of courses

@markocupic Another pull request for the missing output of mountain guide in detail page of courses.
Thanks for merging it!
Have a great week!