### PR TITLE
fix/event-status-valignment

### DIFF
--- a/contao/templates/modules/calendar/event_list/event_list_partial_course.html.twig
+++ b/contao/templates/modules/calendar/event_list/event_list_partial_course.html.twig
@@ -17,7 +17,7 @@
                 <!-- Start right col -->
                 <div class="col-sm-9 col-xl-7">
                     <div class="title d-flex align-items-start mb-2">
-                        <span class="event-state-icon lh-base pt-1" data-bs-toggle="tooltip" data-placement="top" v-bind:aria-label="row.eventStateLabel" v-bind:data-title="row.eventStateLabel" v-bind:class="row.eventState"> </span>
+                        <span class="event-state-icon fa-fw" data-bs-toggle="tooltip" data-placement="top" v-bind:aria-label="row.eventStateLabel" v-bind:data-title="row.eventStateLabel" v-bind:class="row.eventState"> </span>
                         <a v-bind:href="row.eventUrl" data-has-event-href="true" v-bind:data-href="row.eventUrl" class="event-title-link lh-base">
                             <h4 class="d-flex headline m-0 p-0 lh-base">
                                 <% row.title %>


### PR DESCRIPTION
fix: vertical alignment of event status icon of course list

https://github.com/jonasmueller1/sac-pilatus-website/issues/73