### PR TITLE
style/design-fs-level

### DIFF
--- a/public/css/be_stylesheet.css
+++ b/public/css/be_stylesheet.css
@@ -1,8 +1,12 @@
+/** General **/
+.text-decoration-underline {
+	text-decoration: underline;
+}
+
 /** multicolumn wizard fix: Fix cutted of sentences issue on small screens in the bottom-/tooltip section */
 [class*="mcwColumnCount_"] .tl_help.tl_tip {
 	height: auto !important;
 }
-
 /** End multicolumn wizard fix */
 
 #tl_buttons {

--- a/src/DataContainer/CalendarEvents.php
+++ b/src/DataContainer/CalendarEvents.php
@@ -1413,7 +1413,7 @@ class CalendarEvents
 
         if (null !== $eventReleaseLevelModel) {
             $strLevel = sprintf(
-                '<span class="release-level-%s" title="Freigabestufe: %s">FS: %s</span> ',
+                '<span class="release-level-%s" title="Freigabestufe: %s"><u>FS: %s</u></span> ',
                 $eventReleaseLevelModel->level,
                 $eventReleaseLevelModel->title,
                 $eventReleaseLevelModel->level,

--- a/src/DataContainer/CalendarEvents.php
+++ b/src/DataContainer/CalendarEvents.php
@@ -1413,7 +1413,7 @@ class CalendarEvents
 
         if (null !== $eventReleaseLevelModel) {
             $strLevel = sprintf(
-                '<span class="release-level-%s" title="Freigabestufe: %s"><u>FS: %s</u></span> ',
+                '<span class="release-level-%s text-decoration-underline" title="Freigabestufe: %s">FS: %s</span> ',
                 $eventReleaseLevelModel->level,
                 $eventReleaseLevelModel->title,
                 $eventReleaseLevelModel->level,


### PR DESCRIPTION
style: underline 'FS: x' as it is clickable for any help/popup in Update CalendarEvents.php

Idea to separate `FS: x` from event name a little bit.