### PR TITLE
feature/show-min-members

### DIFF
--- a/contao/templates/modules/calendar/event_reader/event_kurs_detailview_sac.html.twig
+++ b/contao/templates/modules/calendar/event_reader/event_kurs_detailview_sac.html.twig
@@ -285,7 +285,7 @@
                     <div class="booking-counter event-detail event-info-box icon-box-small">
                         <h5>Bestätigte Anmeldungen</h5>
                         <p>{{ get_event_data(model, 'bookingCounterAsText') }}</p>
-                        {% if not get_event_data(model, 'minMembers') is empty and get_event_data(model, 'minMembers') != 0 %}
+                        {% if get_event_data(model, 'minMembers')|default(0) > 0 %}
                             <p><small>(min. {{ get_event_data(model, 'minMembers') }} Teilnehmende)</small></p>
                         {% endif %}
                     </div>

--- a/contao/templates/modules/calendar/event_reader/event_kurs_detailview_sac.html.twig
+++ b/contao/templates/modules/calendar/event_reader/event_kurs_detailview_sac.html.twig
@@ -285,6 +285,9 @@
                     <div class="booking-counter event-detail event-info-box icon-box-small">
                         <h5>Bestätigte Anmeldungen</h5>
                         <p>{{ get_event_data(model, 'bookingCounterAsText') }}</p>
+                        {% if not get_event_data(model, 'minMembers') is empty and get_event_data(model, 'minMembers') != 0 %}
+                            <p><small>(min. {{ get_event_data(model, 'minMembers') }} Teilnehmende)</small></p>
+                        {% endif %}
                     </div>
                 {% endif %}
 

--- a/contao/templates/modules/calendar/event_reader/event_tour_detailview_sac.html.twig
+++ b/contao/templates/modules/calendar/event_reader/event_tour_detailview_sac.html.twig
@@ -149,7 +149,7 @@
                     <div class="booking-counter event-detail event-info-box icon-box-small">
                         <h5>Bestätigte Anmeldungen</h5>
                         <p>{{ get_event_data(model, 'bookingCounterAsText') }}</p>
-                        {% if not get_event_data(model, 'minMembers') is empty and get_event_data(model, 'minMembers') != 0 %}
+                        {% if get_event_data(model, 'minMembers')|default(0) > 0 %}
                             <p><small>(min. {{ get_event_data(model, 'minMembers') }} Teilnehmende)</small></p>
                         {% endif %}
                     </div>

--- a/contao/templates/modules/calendar/event_reader/event_tour_detailview_sac.html.twig
+++ b/contao/templates/modules/calendar/event_reader/event_tour_detailview_sac.html.twig
@@ -149,6 +149,9 @@
                     <div class="booking-counter event-detail event-info-box icon-box-small">
                         <h5>Bestätigte Anmeldungen</h5>
                         <p>{{ get_event_data(model, 'bookingCounterAsText') }}</p>
+                        {% if not get_event_data(model, 'minMembers') is empty and get_event_data(model, 'minMembers') != 0 %}
+                            <p><small>(min. {{ get_event_data(model, 'minMembers') }} Teilnehmende)</small></p>
+                        {% endif %}
                     </div>
                 {% endif %}
             </div>

--- a/src/Resources/contao/classes/CalendarEventsHelper.php
+++ b/src/Resources/contao/classes/CalendarEventsHelper.php
@@ -205,6 +205,10 @@ class CalendarEventsHelper
                 $value = static::getBookingCounter($objEvent, true);
                 break;
 
+            case 'minMembers':
+                $value = $objEvent->minMembers;
+                break;
+
             case 'tourTechDifficultiesAsArray':
                 $value = static::getTourTechDifficultiesAsArray($objEvent, false, false);
                 break;


### PR DESCRIPTION
feat: show min members in detail page of events

@markocupic 
The min. TNs (`minMembers` in `tl_calendar_events`) for an event is getting more important for our "Tourenchef" (it is controlled by the "Tourenkommission"). Therefore we shall show this value for all events if a value is set (!= 0) as a indication for all members (execution or cancellation of event).

Thank you for reviewing and testing.