### PR TITLE
features/add-release-level-dashboard

### DIFF
--- a/src/Controller/BackendHomeScreen/DashboardController.php
+++ b/src/Controller/BackendHomeScreen/DashboardController.php
@@ -181,6 +181,7 @@ class DashboardController
             $event['title'] = $title;
             $event['date'] = date($this->configAdapter->get('dateFormat'), (int) $eventModel->startDate);
             $event['state_icon'] = $this->calendarEventsHelperAdapter->getEventStateIcon($eventModel);
+            $event['release_level'] = $this->calendarEventsHelperAdapter->getEventReleaseLevelAsString($eventModel);
             $event['href_eventListing'] = $hrefEventListing;
             $event['href_email'] = $this->generateEmailHref($eventModel);
             $event['href_event'] = $hrefEvent;

--- a/src/Resources/contao/classes/CalendarEventsHelper.php
+++ b/src/Resources/contao/classes/CalendarEventsHelper.php
@@ -46,6 +46,7 @@ use Markocupic\SacEventToolBundle\Model\CalendarEventsMemberModel;
 use Markocupic\SacEventToolBundle\Model\CourseMainTypeModel;
 use Markocupic\SacEventToolBundle\Model\CourseSubTypeModel;
 use Markocupic\SacEventToolBundle\Model\EventOrganizerModel;
+use Markocupic\SacEventToolBundle\Model\EventReleaseLevelPolicyModel;
 use Markocupic\SacEventToolBundle\Model\EventTypeModel;
 use Markocupic\SacEventToolBundle\Model\TourDifficultyModel;
 use Markocupic\SacEventToolBundle\Model\TourTypeModel;
@@ -1256,5 +1257,22 @@ class CalendarEventsHelper
         }
 
         return $strPortalLink;
+    }
+
+    public static function getEventReleaseLevelAsString(CalendarEventsModel $objEvent): string|null
+    {
+        if (empty($objEvent->id) || empty($objEvent->eventReleaseLevel)) {
+            return null;
+        }
+        
+        $strLevel = null;
+        $eventReleaseLevelModel = EventReleaseLevelPolicyModel::findByPk($objEvent->eventReleaseLevel);
+        if (null !== $eventReleaseLevelModel) {
+            $strLevel = sprintf(
+                'FS: %s',
+                $eventReleaseLevelModel->level
+            );
+        }
+        return $strLevel;
     }
 }

--- a/templates/BackendHomeScreen/dashboard.html.twig
+++ b/templates/BackendHomeScreen/dashboard.html.twig
@@ -38,6 +38,9 @@
                         <td class="my-events-state-col text-align-left">{{ event.state_icon|raw }}</td>
                         <td class="my-events-title-col text-align-left">
                             <a href="{{ event.href_event }}" style="text-decoration:underline" title="{{ 'MSC.bhs_dashb_editEvent'|trans({}, 'contao_default') }}"><strong>{{ event.title }}</strong></a>
+                            {% if event.release_level is not empty %}
+                                <small>({{ event.release_level }})</small>
+                            {% endif %}
                         </td>
                         <td class="my-events-icon-col text-align-center">
                             <a href="{{ event.href_preview }}" target="_blank" title="{{ 'MSC.bhs_dashb_livePreview'|trans({}, 'contao_default') }}">


### PR DESCRIPTION
feat: add event release level as string on dashboard

@markocupic
I discovered that many TLs still have `FS1` for their 2024's tours even though they should already increased it to `FS2` ("Tourenkommission" is ongoing...).
I tried to show the release level as string on the dashboard for having an overview about the release levels of all individual events.
Probably, it is not yet fully working 😉 
Please have a look.
Thank you and happy holidays!