### PR TITLE
Feature/course level details

### DIFF
--- a/contao/templates/modules/calendar/event_list/event_list_partial_course.html.twig
+++ b/contao/templates/modules/calendar/event_list/event_list_partial_course.html.twig
@@ -28,6 +28,9 @@
                         <strong>[[ row.courseTypeLevel0Name ]]: [[ row.courseTypeLevel1Name ]]</strong>
                     </div>
                     <div class="detail-item">
+                        Kursstufe: [[ row.courseLevelName ]]
+                    </div>
+                    <div class="detail-item">
                         <i class="fa fa-fw fa-user"></i> <span>Leitung: [[ row.instructorsWithQualification ]]</span>
                     </div>
                     <div class="detail-item">

--- a/contao/templates/modules/calendar/event_list/event_list_partial_course.html.twig
+++ b/contao/templates/modules/calendar/event_list/event_list_partial_course.html.twig
@@ -41,8 +41,14 @@
                     <div class="detail-item">
                         <i class="fa fa-fw fa-user"></i> <span>Leitung: [[ row.instructorsWithQualification ]]</span>
                     </div>
-                    <div class="detail-item">
+                    <div class="detail-item d-flex flex-wrap">
                         <div v-html="row.bookingCounter" class="me-1"></div>
+                        <div v-if="row.suitableForBeginners" class="me-1">
+                            <span class="badge badge-pill bg-warning" data-bs-toggle="tooltip" data-placement="top" data-title="Für Einsteiger geeignet">
+                                <i class="event-for-beginners"></i>
+                            </span>
+                        </div>
+                        <div v-if="row.isPublicTransportEvent" v-html="row.getPublicTransportBadge" class="me-1"></div>
                     </div>
                     {# The logo will not be displayed if the event is organized by multiple groups. #}
                     <div class="detail-item">

--- a/contao/templates/modules/calendar/event_list/event_list_partial_course.html.twig
+++ b/contao/templates/modules/calendar/event_list/event_list_partial_course.html.twig
@@ -20,7 +20,7 @@
                         <span class="event-state-icon" v-html="row.eventStateIcon" data-bs-toggle="tooltip" data-placement="top" v-bind:aria-label="row.eventStateLabel" v-bind:data-title="row.eventStateLabel" v-bind:class="row.eventState"></span>
                         <a v-bind:href="row.eventUrl" data-has-event-href="true" v-bind:data-href="row.eventUrl" class="event-title-link lh-base">
                             <h4 class="d-flex headline m-0 p-0 lh-base">
-                                [[ row.title ]]
+                                <strong>[[ row.title ]]</strong>
                             </h4>
                         </a>
                     </div>
@@ -28,18 +28,18 @@
                         <strong>[[ row.courseTypeLevel0Name ]]: [[ row.courseTypeLevel1Name ]]</strong>
                     </div>
                     <div class="detail-item">
-                        Kursstufe: [[ row.courseLevelName ]]
-                    </div>
-                    <div class="detail-item">
-                        <i class="fa fa-fw fa-user"></i> <span>Leitung: [[ row.instructorsWithQualification ]]</span>
+                        <i class="fa fa-fw fa-bars"></i> <span>Kursstufe: [[ row.courseLevelName ]]</span>
                     </div>
                     <div class="detail-item">
                         <i class="fa fa-fw fa-calendar-alt"></i>
-                        <span v-html="row.eventPeriodLgInline"></span>
+                        &nbsp;<span v-html="row.eventPeriodLgInline"></span> <small>(Dauer: <span v-html="row.eventDuration"></span>)</small>
                     </div>
                     {# if the event has been rescheduled #}
                     <div class="detail-item small text-danger" v-if="row.eventState === 'event_status_6'">
                         <span v-html="row.eventStateLabel"></span>
+                    </div>
+                    <div class="detail-item">
+                        <i class="fa fa-fw fa-user"></i> <span>Leitung: [[ row.instructorsWithQualification ]]</span>
                     </div>
                     <div class="detail-item">
                         <div v-html="row.bookingCounter" class="me-1"></div>

--- a/contao/templates/modules/calendar/event_reader/event_kurs_detailview_sac.html.twig
+++ b/contao/templates/modules/calendar/event_reader/event_kurs_detailview_sac.html.twig
@@ -180,6 +180,24 @@
             </div>
             {# End Anmeldung #}
             <div class="box-layout-white">
+                {% if not get_event_data(model, 'courseTypeLevel0Name') is empty and not get_event_data(model, 'courseTypeLevel1Name') is empty %}
+                    <!-- indexer::continue -->
+                    <div class="courseType event-detail event-info-box icon-box-small">
+                        <h5>Kursart</h5>
+                        <p><strong>{{ get_event_data(model, 'courseTypeLevel0Name') }}: {{ get_event_data(model, 'courseTypeLevel1Name') }}</strong></p>
+                    </div>
+                    <!-- indexer::stop -->
+                {% endif %}
+
+                {% if not get_event_data(model, 'courseLevelName') is empty %}
+                    <!-- indexer::continue -->
+                    <div class="courseLevel event-detail event-info-box icon-box-small">
+                        <h5>Kursstufe</h5>
+                        <p>{{ get_event_data(model, 'courseLevelName') }}</p>
+                    </div>
+                    <!-- indexer::stop -->
+                {% endif %}
+
                 {% if not get_event_data(model, 'issues') is empty %}
                     <div class="topics event-detail event-info-box icon-box-small">
                         <!-- indexer::continue -->

--- a/src/Resources/contao/classes/CalendarEventsHelper.php
+++ b/src/Resources/contao/classes/CalendarEventsHelper.php
@@ -250,6 +250,10 @@ class CalendarEventsHelper
                     $value = $parser->replace(sprintf('{{picture::%s?size=%s}}', $src, $pictureSize));
                 }
                 break;
+                
+            case 'courseLevelName':
+                $value = $GLOBALS['TL_CONFIG']['SAC-EVENT-TOOL-CONFIG']['courseLevel'][$objEvent->courseLevel] ?? '';
+                break;              
 
             case 'courseTypeLevel0Name':
                 $value = CourseMainTypeModel::findByPk($objEvent->courseTypeLevel0)->name;


### PR DESCRIPTION
Changes:
- feat: add public transport badge and suitable for beginners to course list
- feat: add course level to list view
- feat: add course level and type to detail view
- style: formatting and sorting of course list

@markocupic I improved the course list and detail view with some missing fields on the website. Thank you for reviewing.

Not sure, if `[[ row.courseLevelName ]]` in `contao\templates\modules\calendar\event_list\event_list_partial_course.html.twig` works or where it should come from. I guess from `eventlist_vue.js`?