### PR TITLE
Improve permissions on tl_member and tl_user

### DIFF
--- a/src/DataContainer/Member.php
+++ b/src/DataContainer/Member.php
@@ -16,10 +16,9 @@ namespace Markocupic\SacEventToolBundle\DataContainer;
 
 use Contao\Controller;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
+use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Contao\DataContainer;
 use Contao\Message;
-use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Exception;
 use Markocupic\SacEventToolBundle\User\FrontendUser\ClearFrontendUserData;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Routing\RouterInterface;
@@ -32,7 +31,6 @@ class Member
     public function __construct(
         private readonly Security $security,
         private readonly ClearFrontendUserData $clearFrontendUserData,
-        private readonly Connection $connection,
         private readonly RouterInterface $router,
         private readonly TranslatorInterface $translator,
         private readonly Util $util,
@@ -67,15 +65,12 @@ class Member
         $arrFieldNames = array_keys($GLOBALS['TL_DCA']['tl_member']['fields']);
 
         foreach ($arrFieldNames as $fieldName) {
-            if (!$this->security->isGranted('contao_user.alexf', 'tl_member::'.$fieldName)) {
+            if (!$this->security->isGranted(ContaoCorePermissions::USER_CAN_EDIT_FIELD_OF_TABLE, 'tl_member::'.$fieldName)) {
                 $GLOBALS['TL_DCA']['tl_member']['fields'][$fieldName]['eval']['doNotShow'] = true;
             }
         }
     }
 
-    /**
-     * @throws Exception
-     */
     #[AsCallback(table: 'tl_member', target: 'fields.sectionId.options', priority: 100)]
     public function listSacSections(): array
     {

--- a/src/DataContainer/Member.php
+++ b/src/DataContainer/Member.php
@@ -60,14 +60,28 @@ class Member
     }
 
     #[AsCallback(table: 'tl_member', target: 'config.onload', priority: 100)]
-    public function doNotShowFieldIfCanNotEdit(DataContainer $dc = null): void
+    public function checkPermission(DataContainer $dc = null): void
     {
         if (!$dc) {
-            // The ModulePersonalData frontend module is triggering tl_member onload callbacks as well,
+            // The personal data frontend module is triggering the onload callbacks as well,
             // but without the DataContainer $dc method parameter.
             return;
         }
 
+        if ($this->security->isGranted('ROLE_ADMIN')) {
+            return;
+        }
+
+        // Adding new records is not allowed to non admins.
+        $GLOBALS['TL_DCA']['tl_member']['config']['closed'] = true;
+        $GLOBALS['TL_DCA']['tl_member']['config']['notCopyable'] = true;
+        unset($GLOBALS['TL_DCA']['tl_member']['list']['operations']['copy']);
+
+        // Deleting records is not allowed to non admins.
+        $GLOBALS['TL_DCA']['tl_member']['config']['notDeletable'] = true;
+        unset($GLOBALS['TL_DCA']['tl_member']['list']['operations']['delete']);
+
+        // Do not show fields without write permission.
         $arrFieldNames = array_keys($GLOBALS['TL_DCA']['tl_member']['fields']);
 
         foreach ($arrFieldNames as $fieldName) {

--- a/src/DataContainer/Member.php
+++ b/src/DataContainer/Member.php
@@ -60,8 +60,14 @@ class Member
     }
 
     #[AsCallback(table: 'tl_member', target: 'config.onload', priority: 100)]
-    public function doNotShowFieldIfCanNotEdit(DataContainer $dc): void
+    public function doNotShowFieldIfCanNotEdit(DataContainer $dc = null): void
     {
+        if (!$dc) {
+            // The ModulePersonalData frontend module is triggering tl_member onload callbacks as well,
+            // but without the DataContainer $dc method parameter.
+            return;
+        }
+
         $arrFieldNames = array_keys($GLOBALS['TL_DCA']['tl_member']['fields']);
 
         foreach ($arrFieldNames as $fieldName) {

--- a/src/DataContainer/User.php
+++ b/src/DataContainer/User.php
@@ -35,14 +35,14 @@ class User
     public const TABLE = 'tl_user';
 
     public function __construct(
-        private readonly ContaoFramework $framework,
-        private readonly Util $util,
-        private readonly RequestStack $requestStack,
         private readonly Connection $connection,
-        private readonly TranslatorInterface $translator,
+        private readonly ContaoFramework $framework,
         private readonly Countries $countries,
-        private readonly Security $security,
         private readonly MaintainBackendUsersHomeDirectory $maintainBackendUsersHomeDirectory,
+        private readonly RequestStack $requestStack,
+        private readonly Security $security,
+        private readonly TranslatorInterface $translator,
+        private readonly Util $util,
     ) {
     }
 
@@ -73,6 +73,18 @@ class User
 
         if ('user' === $request->query->get('do') && 'edit' === $request->query->get('act') && '' !== $request->query->get('ref')) {
             $GLOBALS['TL_JAVASCRIPT'][] = Bundle::ASSET_DIR.'/js/backend_member_autocomplete.js';
+        }
+    }
+
+    #[AsCallback(table: 'tl_user', target: 'config.onload', priority: 100)]
+    public function doNotShowFieldIfCanNotEdit(DataContainer $dc): void
+    {
+        $arrFieldNames = array_keys($GLOBALS['TL_DCA']['tl_user']['fields']);
+
+        foreach ($arrFieldNames as $fieldName) {
+            if (!$this->security->isGranted('contao_user.alexf', 'tl_user::'.$fieldName)) {
+                $GLOBALS['TL_DCA']['tl_user']['fields'][$fieldName]['eval']['doNotShow'] = true;
+            }
         }
     }
 

--- a/src/DataContainer/User.php
+++ b/src/DataContainer/User.php
@@ -75,8 +75,22 @@ class User
     }
 
     #[AsCallback(table: 'tl_user', target: 'config.onload', priority: 100)]
-    public function doNotShowFieldIfCanNotEdit(DataContainer $dc): void
+    public function checkPermission(DataContainer $dc): void
     {
+        if ($this->security->isGranted('ROLE_ADMIN')) {
+            return;
+        }
+
+        // Adding new records is not allowed to non admins.
+        $GLOBALS['TL_DCA']['tl_user']['config']['closed'] = true;
+        $GLOBALS['TL_DCA']['tl_user']['config']['notCopyable'] = true;
+        unset($GLOBALS['TL_DCA']['tl_user']['list']['operations']['copy']);
+
+        // Deleting records is not allowed to non admins.
+        $GLOBALS['TL_DCA']['tl_user']['config']['notDeletable'] = true;
+        unset($GLOBALS['TL_DCA']['tl_user']['list']['operations']['delete']);
+
+        // Do not show fields without write permission.
         $arrFieldNames = array_keys($GLOBALS['TL_DCA']['tl_user']['fields']);
 
         foreach ($arrFieldNames as $fieldName) {


### PR DESCRIPTION
Do not show fields if the user has no write permission on it.
Do only allow copying and deleting records to admins.