### PR TITLE
change the waiting list icon to orange color instead of red

### DIFF
--- a/assets/icons/event_states/event_status_8.svg
+++ b/assets/icons/event_states/event_status_8.svg
@@ -5,7 +5,7 @@
    id="svg834"
    width="16"
    height="16"
-   fill="#BE0B15"
+   fill="#FF9900"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg">
   <defs


### PR DESCRIPTION
change the waiting list icon to orange color instead of red in order to get more registration on the waiting list
(because there is still a chance to get a place in the event and the registrations are no blocked/closed as red color may indicate)

SAC/CAS has a orange waiting list icon as well:
![image](https://github.com/user-attachments/assets/6cd27195-0a7c-465b-a4a3-d96ab15b511e)

@markocupic What do you think for this proposal? It would make the waiting list more explicit and open (red is more like closed/stop, but this is not true). Thanks.