### PR TITLE
enhance button text for subscription status change to cancelled

### DIFF
--- a/contao/templates/backend/tl_calendar_events_member/be_calendar_events_registration_dashboard.html.twig
+++ b/contao/templates/backend/tl_calendar_events_member/be_calendar_events_registration_dashboard.html.twig
@@ -21,7 +21,7 @@
             {% set state = constant('\\Markocupic\\SacEventToolBundle\\Config\\EventSubscriptionState::SUBSCRIPTION_REFUSED') %}
             <button type="submit" name="changeSubscriptionStateWithEmail" value="{{ state }}" onclick="if (!confirm('{{ onclick_confirm_A }}'))return false;Backend.getScrollOffset()" class="tl_submit btn-refuse-with-email">Ablehnen mit E-Mail</button>
             {% set state = constant('\\Markocupic\\SacEventToolBundle\\Config\\EventSubscriptionState::USER_HAS_UNSUBSCRIBED') %}
-            <button type="submit" name="changeSubscriptionStateWithEmail" value="{{ state }}" onclick="if (!confirm('{{ onclick_confirm_B }}'))return false;Backend.getScrollOffset()" class="tl_submit btn-cancel-with-email">Stornieren (abgemeldet) mit E-Mail</button>
+            <button type="submit" name="changeSubscriptionStateWithEmail" value="{{ state }}" onclick="if (!confirm('{{ onclick_confirm_B }}'))return false;Backend.getScrollOffset()" class="tl_submit btn-cancel-with-email">Abmeldung durch TN mit E-Mail</button>
         {% endif %}
     </div>
 


### PR DESCRIPTION
@markocupic 
Der `Anmeldestatus stornieren` ist etwas zweideutig. Es gibt einige TLs, welche diesen Status zusätzlich brauchen (neben den eigentlichen TN Abmeldungen), um den TNs mitzuteilen, dass der Event abgesagt wurde.
Allerdings wäre es gut (finde ich), wenn alle diesen nur für die TN Abmeldungen benutzen würden (insb. wegen Statistik etc.). Bei einem abgesagten Event muss ja eigentlich den Anmeldestatus nicht geändert werden (nur Eventstatus und ein E-Mail an die TNs, was auch schneller und einfacher ist).
Siehe: https://www.sac-pilatus.ch/service/anleitungen-und-tutorials.html#event-absagen 
Deshalb diese einfache Änderung.
Was ist deine Meinung? Ist dies in deinem Sinn oder was war deine ursprüngliche Idee?
Danke dir. LG 